### PR TITLE
replace specification with company or implementor url

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -1,8 +1,8 @@
 ## Registry
 
-This section is the registry of identifiers used by the `tracestate` defined in
-[[!TRACE-CONTEXT]].
+This section is the registry of identifiers used by the `tracestate`, which is defined at
+<https://www.w3.org/TR/trace-context/>.
 
-| Identifier                      | Public Specification(s)                                                                               | Requestor Contact                                   |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------|
-| @@REPLACEME@@                          | [[!TRACE-CONTEXT]]                                                                                    | [W3C](https://www.w3.org/2018/distributed-tracing/) |
+| Identifier                             | Implemetation or Company URL                                                                          | Requestor Contact                                   |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------|
+| @@REPLACEME@@                          | https://www.w3.org/TR/trace-context/                                                                  | [W3C](https://www.w3.org/2018/distributed-tracing/) |


### PR DESCRIPTION
As discussed in the workshop, update the table format to replace specification with company or implementation url.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/trace-state-ids-registry/pull/6.html" title="Last updated on Jul 28, 2020, 7:19 PM UTC (346136c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-state-ids-registry/6/3c4ed0f...dyladan:346136c.html" title="Last updated on Jul 28, 2020, 7:19 PM UTC (346136c)">Diff</a>