### PR TITLE
Add es identifier for Elastic

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -3,7 +3,8 @@
 This section is the registry of identifiers used by the `tracestate`, which is defined at
 <https://www.w3.org/TR/trace-context/>.
 
-| Identifier                             | Implemetation or Company URL                                                                          | Requestor Contact                                   |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------|
-| `in`                          | `n/a`                                                                                    | [Instana](https://www.instana.com/) |
+| Identifier                             | Implemetation or Company URL                                                                          |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `in`                                   | [Instana](https://www.instana.com/)                                                                   |
+| `es`                                   | [Elastic](https://www.elastic.co/)                                                                    |
 


### PR DESCRIPTION
This PR adds `es` identifier for [Elastic](https://elastic.co)

Also, I've removed `Requestor Contact` column according to #8 

Fixes #8


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jahtalab/trace-state-ids-registry/pull/9.html" title="Last updated on Oct 22, 2020, 2:13 PM UTC (082d906)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-state-ids-registry/9/635dd4c...jahtalab:082d906.html" title="Last updated on Oct 22, 2020, 2:13 PM UTC (082d906)">Diff</a>