### PR TITLE
trace-state to tracestate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
-# Trace State Ids Registry
+# Tracestate Ids Registry
 
 [Trace Context](https://w3c.github.io/trace-context/) defines the `tracestate` header.
 
-See [Trace state Ids Registry](https://w3c.github.io/trace-state-ids-registry/).
+See [Tracestate Ids Registry](https://w3c.github.io/trace-state-ids-registry/).
 
 ## Team Communication
 

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
-    <title>Trace State Ids Registry</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async="" class="remove"></script>
+    <title>Tracestate Ids Registry</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" async="" class="remove"></script>
     <script class="remove">
       var respecConfig = {
           // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
@@ -11,7 +11,7 @@
           // specStatus:           "WG-NOTE",
 
           // the specification's short name, as in http://www.w3.org/TR/short-name/
-          shortName:            "trace-state-ids-registry",
+          shortName:            "tracestate-ids-registry",
 
           format: "markdown",
 

--- a/w3c.json
+++ b/w3c.json
@@ -1,6 +1,6 @@
  {
     "group":      [108594]
-,   "contacts":   ["plehegar"]
+,   "contacts":   ["caribouW3"]
 ,   "policy":     "open"
 ,   "repo-type":  "note"
 }


### PR DESCRIPTION
I suggest we switch to the single word tracestate to make sure it's clear that we suggest to use a single word


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-state-ids-registry/pull/10.html" title="Last updated on Oct 31, 2020, 7:00 AM UTC (9fe222c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-state-ids-registry/10/df12264...9fe222c.html" title="Last updated on Oct 31, 2020, 7:00 AM UTC (9fe222c)">Diff</a>