### PR TITLE
Add SolarWinds identifier sw

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -9,3 +9,4 @@ This section is the registry of identifiers used by the `tracestate`, which is d
 | `es`                                   | [Elastic](https://www.elastic.co/)                                                                    |
 | `dt`                                   | [Dynatrace](https://www.dynatrace.com/)                                                               |
 | `nr`                                   | [New Relic](https://newrelic.com/)                                                                    |
+| `sw`                                   | [SolarWinds](https://solarwinds.com/)                                                                 |


### PR DESCRIPTION
Add the `sw` identifier for SolarWinds.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/solarwindscloud/tracestate-ids-registry/pull/14.html" title="Last updated on Nov 4, 2021, 11:02 PM UTC (dfe24e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tracestate-ids-registry/14/20999ac...solarwindscloud:dfe24e3.html" title="Last updated on Nov 4, 2021, 11:02 PM UTC (dfe24e3)">Diff</a>