### PR TITLE
Add ot=OpenTelemtry

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -9,3 +9,4 @@ This section is the registry of identifiers used by the `tracestate`, which is d
 | `es`                                   | [Elastic](https://www.elastic.co/)                                                                    |
 | `dt`                                   | [Dynatrace](https://www.dynatrace.com/)                                                               |
 | `nr`                                   | [New Relic](https://newrelic.com/)                                                                    |
+| `ot`                                   | [OpenTelemetry](https://opentelemetry.io/)                                                            |


### PR DESCRIPTION
Adds an identifier for OpenTelemetry. 

This constant has been agreed to in https://github.com/open-telemetry/opentelemetry-specification/pull/1852


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jmacd/tracestate-ids-registry/pull/15.html" title="Last updated on Oct 11, 2021, 5:42 PM UTC (a592584)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tracestate-ids-registry/15/12e74d0...jmacd:a592584.html" title="Last updated on Oct 11, 2021, 5:42 PM UTC (a592584)">Diff</a>