### PR TITLE
Add ls=Lightstep

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -9,3 +9,4 @@ This section is the registry of identifiers used by the `tracestate`, which is d
 | `es`                                   | [Elastic](https://www.elastic.co/)                                                                    |
 | `dt`                                   | [Dynatrace](https://www.dynatrace.com/)                                                               |
 | `nr`                                   | [New Relic](https://newrelic.com/)                                                                    |
+| `ls`                                   | [Lightstep](https://lightstep.com/)                                                                   |


### PR DESCRIPTION
Lightstep wishes to reserve the identifier "ls".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jmacd/tracestate-ids-registry/pull/16.html" title="Last updated on Nov 4, 2021, 5:00 PM UTC (6cabb5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tracestate-ids-registry/16/cbc45a9...jmacd:6cabb5f.html" title="Last updated on Nov 4, 2021, 5:00 PM UTC (6cabb5f)">Diff</a>