### PR TITLE
Add sn vendor code for ServiceNow trace state

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -13,3 +13,4 @@ This section is the registry of identifiers used by the `tracestate`, which is d
 | `ls`                                   | [Lightstep](https://lightstep.com/)                                                                   |
 | `ot`                                   | [OpenTelemetry](https://opentelemetry.io/)                                                            |
 | `ms`                                   | [Microsoft](https://www.microsoft.com/)                                                               |
+| `sn`                                   | [ServiceNow](https://servicenow.com/)                                                                   |


### PR DESCRIPTION
Request to reserve the vendor code "sn" for ServiceNow.
While ServiceNow has acquired Lightstep (already registered, "ls"), we wish to leave "ls" reserved.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jmacd/tracestate-ids-registry/pull/18.html" title="Last updated on Feb 7, 2024, 8:12 PM UTC (f940a01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tracestate-ids-registry/18/217dcfa...jmacd:f940a01.html" title="Last updated on Feb 7, 2024, 8:12 PM UTC (f940a01)">Diff</a>