### PR TITLE
Add Dynatrace entry for 'dtr' in registry

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -8,6 +8,7 @@ This section is the registry of identifiers used by the `tracestate`, which is d
 | `in`                                   | [Instana](https://www.instana.com/)                                                                   |
 | `es`                                   | [Elastic](https://www.elastic.co/)                                                                    |
 | `dt`                                   | [Dynatrace](https://www.dynatrace.com/)                                                               |
+| `dtr`                                  | [Dynatrace](https://www.dynatrace.com/)                                                               |
 | `nr`                                   | [New Relic](https://newrelic.com/)                                                                    |
 | `sw`                                   | [SolarWinds](https://solarwinds.com/)                                                                 |
 | `ls`                                   | [Lightstep](https://lightstep.com/)                                                                   |


### PR DESCRIPTION
Dynatrace uses the `dtr` identifier for RUM requests in addition to the normal `dt` identifier for server to server communication.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/trace-state-ids-registry/pull/21.html" title="Last updated on Feb 27, 2026, 1:42 PM UTC (2e442aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tracestate-ids-registry/21/65e6aad...dyladan:2e442aa.html" title="Last updated on Feb 27, 2026, 1:42 PM UTC (2e442aa)">Diff</a>