### PR TITLE
Add Datadog 'dd' entry to registry

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -15,3 +15,4 @@ This section is the registry of identifiers used by the `tracestate`, which is d
 | `ms`                                   | [Microsoft](https://www.microsoft.com/)                                                               |
 | `sn`                                   | [ServiceNow](https://servicenow.com/)                                                                 |
 | `sb`                                   | [SmartBear](https://www.smartbear.com/)                                                               |
+| `dd`                                   | [Datadog](https://www.datadoghq.com/)                                                                 |


### PR DESCRIPTION
Datadog uses the `dd` identifier for propagating information in the W3C tracestate header.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zacharycmontoya/tracestate-ids-registry/pull/22.html" title="Last updated on Mar 2, 2026, 4:51 PM UTC (11530f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tracestate-ids-registry/22/65e6aad...zacharycmontoya:11530f1.html" title="Last updated on Mar 2, 2026, 4:51 PM UTC (11530f1)">Diff</a>